### PR TITLE
[codex] add configurable notification templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ app:
   default_notifier: "telegram" # options: gotify, telegram
   use_topics: true # define if telegram will use topics
 
+notifier:
+  templates:
+    new_offer: "💎 <b>New offer found!</b>\n\n📌 {{.Title}}\n💰 {{.Price}}\n\n🔗 {{.Link}}"
+    circuit_breaker: "🚧 <b>CIRCUIT BREAKER!</b>\nSystem is cooling down for {{.Cooldown}}."
+    error: "❌ <b>Scraper Error:</b> {{.Error}}"
+
 proxy:
   enabled: true
   provider: "proxyscrape"

--- a/cmd/gorimpo/main.go
+++ b/cmd/gorimpo/main.go
@@ -62,6 +62,8 @@ func main() {
 		selectedNotifier = "telegram"
 	}
 
+	notificationTemplates := cfg.Get().Notifier.Templates
+
 	var appNotifier ports.Notifier
 	if selectedNotifier == "gotify" {
 		host := strings.TrimSpace(os.Getenv("GOTIFY_HOST"))
@@ -71,7 +73,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		appNotifier = notifier.NewGotify(host, token)
+		appNotifier = notifier.NewGotify(host, token, notificationTemplates)
 	} else {
 		token := strings.TrimSpace(os.Getenv("TELEGRAM_TOKEN"))
 		chatID := strings.TrimSpace(os.Getenv("TELEGRAM_CHAT_ID"))
@@ -80,7 +82,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		appNotifier = notifier.NewTelegram(token, chatID)
+		appNotifier = notifier.NewTelegram(token, chatID, notificationTemplates)
 	}
 
 	proxyProvider := proxy.NewProxyscrapeProvider(cfg.Get().Proxy.Strategies.Proxyscrape.URL)

--- a/internal/adapters/notifier/gotify.go
+++ b/internal/adapters/notifier/gotify.go
@@ -16,22 +16,31 @@ import (
 var _ ports.Notifier = (*GotifyAdapter)(nil)
 
 type GotifyAdapter struct {
-	host   string
-	token  string
-	apiURL string
-	client *http.Client
-	routes map[string]string
+	host      string
+	token     string
+	apiURL    string
+	client    *http.Client
+	routes    map[string]string
+	templates domain.NotificationTemplates
 }
 
-func NewGotify(host, token string) *GotifyAdapter {
+const defaultGotifyNewOfferTemplate = `{{if .SearchTerm}}🔎 Search: {{.SearchTerm}}
+{{end}}🚨 New find on {{.Source}}
+🎮 {{.Title}}
+💰 Price: {{.Price}}
+{{if .Date}}🕗 Posted on: {{.Date}}
+{{end}}🔗 {{.Link}}`
+
+func NewGotify(host, token string, templates ...domain.NotificationTemplates) *GotifyAdapter {
 	normalizedHost := strings.TrimRight(strings.TrimSpace(host), "/")
 
 	return &GotifyAdapter{
-		host:   normalizedHost,
-		token:  strings.TrimSpace(token),
-		apiURL: fmt.Sprintf("%s/message?token=%s", normalizedHost, strings.TrimSpace(token)),
-		client: &http.Client{Timeout: 10 * time.Second},
-		routes: make(map[string]string),
+		host:      normalizedHost,
+		token:     strings.TrimSpace(token),
+		apiURL:    fmt.Sprintf("%s/message?token=%s", normalizedHost, strings.TrimSpace(token)),
+		client:    &http.Client{Timeout: 10 * time.Second},
+		routes:    make(map[string]string),
+		templates: firstTemplateConfig(templates),
 	}
 }
 
@@ -55,21 +64,36 @@ func (g *GotifyAdapter) SendText(message, category string) error {
 }
 
 func (g *GotifyAdapter) Send(offer domain.Offer, category, searchTerm string, showSearchTerm bool) error {
-	var msg strings.Builder
-
-	if showSearchTerm {
-		fmt.Fprintf(&msg, "🔎 Search: %s\n", searchTerm)
+	msg, err := g.formatOfferMessage(offer, searchTerm, showSearchTerm)
+	if err != nil {
+		return err
 	}
 
-	fmt.Fprintf(&msg, "🚨 New find on %s\n", offer.Source)
-	fmt.Fprintf(&msg, "🎮 %s\n", offer.Title)
-	fmt.Fprintf(&msg, "💰 Price: R$ %.2f\n", offer.Price)
+	return g.SendText(msg, category)
+}
+
+func (g *GotifyAdapter) formatOfferMessage(offer domain.Offer, searchTerm string, showSearchTerm bool) (string, error) {
+	if !showSearchTerm {
+		searchTerm = ""
+	}
+
+	date := ""
 	if !offer.PostDate.IsZero() {
-		fmt.Fprintf(&msg, "🕗 Posted on: %s\n", formatDate(offer.PostDate))
+		date = formatDate(offer.PostDate)
 	}
-	fmt.Fprintf(&msg, "🔗 %s", offer.Link)
 
-	return g.SendText(msg.String(), category)
+	return domain.RenderNotificationTemplate(
+		g.templates.Template(domain.NotificationTemplateNewOffer),
+		defaultGotifyNewOfferTemplate,
+		domain.NotificationTemplateData{
+			Title:      offer.Title,
+			Price:      fmt.Sprintf("R$ %.2f", offer.Price),
+			Link:       offer.Link,
+			Date:       date,
+			Source:     offer.Source,
+			SearchTerm: searchTerm,
+		},
+	)
 }
 
 func (g *GotifyAdapter) SendPhoto(data []byte, caption string, category string) error {

--- a/internal/adapters/notifier/telegram.go
+++ b/internal/adapters/notifier/telegram.go
@@ -19,17 +19,28 @@ import (
 var _ ports.Notifier = (*TelegramAdapter)(nil)
 
 type TelegramAdapter struct {
-	Token  string
-	ChatID string
-	ApiURL string
-	Routes map[string]string
+	Token     string
+	ChatID    string
+	ApiURL    string
+	Routes    map[string]string
+	Templates domain.NotificationTemplates
 }
 
-func NewTelegram(token, chatID string) *TelegramAdapter {
+const defaultTelegramNewOfferTemplate = `{{if .SearchTerm}}🔍 <i>Search: {{.SearchTerm}}</i>
+{{end}}🚨 <b>NEW FIND ON {{.Source}}!</b>
+
+🎮 <b>{{.Title}}</b>
+💰 Price: <b>{{.Price}}</b>{{.Tags}}
+🕗 Posted on: <b>{{.Date}}</b>
+
+🔗 <a href="{{.Link}}">View Listing</a>`
+
+func NewTelegram(token, chatID string, templates ...domain.NotificationTemplates) *TelegramAdapter {
 	return &TelegramAdapter{
-		Token:  token,
-		ChatID: chatID,
-		ApiURL: fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token),
+		Token:     token,
+		ChatID:    chatID,
+		ApiURL:    fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", token),
+		Templates: firstTemplateConfig(templates),
 	}
 }
 
@@ -54,23 +65,32 @@ func (t *TelegramAdapter) SendText(message, category string) error {
 }
 
 func (t *TelegramAdapter) Send(offer domain.Offer, category, searchTerm string, showSearchTerm bool) error {
-	header := "🚨 <b>NEW FIND ON " + offer.Source + "!</b>"
-	if showSearchTerm {
-		header = fmt.Sprintf("🔍 <i>Search: %s</i>\n%s", searchTerm, header)
+	msg, err := t.formatOfferMessage(offer, searchTerm, showSearchTerm)
+	if err != nil {
+		return err
 	}
 
-	tagsStr := formatTags(offer.Tags)
-	msg := fmt.Sprintf(
-		"%s\n\n🎮 <b>%s</b>\n💰 Price: <b>R$ %.2f</b>%s\n🕗 Posted on: <b>%s</b>\n\n🔗 <a href=\"%s\">View Listing</a>",
-		header,
-		offer.Title,
-		offer.Price,
-		tagsStr,
-		formatDate(offer.PostDate),
-		offer.Link,
-	)
-
 	return t.SendText(msg, category)
+}
+
+func (t *TelegramAdapter) formatOfferMessage(offer domain.Offer, searchTerm string, showSearchTerm bool) (string, error) {
+	if !showSearchTerm {
+		searchTerm = ""
+	}
+
+	return domain.RenderNotificationTemplate(
+		t.Templates.Template(domain.NotificationTemplateNewOffer),
+		defaultTelegramNewOfferTemplate,
+		domain.NotificationTemplateData{
+			Title:      offer.Title,
+			Price:      fmt.Sprintf("R$ %.2f", offer.Price),
+			Link:       offer.Link,
+			Date:       formatDate(offer.PostDate),
+			Source:     offer.Source,
+			SearchTerm: searchTerm,
+			Tags:       formatTags(offer.Tags),
+		},
+	)
 }
 
 func (t *TelegramAdapter) SendPhoto(data []byte, caption string, category string) error {

--- a/internal/adapters/notifier/templates.go
+++ b/internal/adapters/notifier/templates.go
@@ -1,0 +1,11 @@
+package notifier
+
+import "github.com/LXSCA7/gorimpo/internal/core/domain"
+
+func firstTemplateConfig(templates []domain.NotificationTemplates) domain.NotificationTemplates {
+	if len(templates) == 0 {
+		return domain.NotificationTemplates{}
+	}
+
+	return templates[0]
+}

--- a/internal/adapters/notifier/templates_test.go
+++ b/internal/adapters/notifier/templates_test.go
@@ -1,0 +1,96 @@
+package notifier
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LXSCA7/gorimpo/internal/core/domain"
+)
+
+func testOffer() domain.Offer {
+	return domain.Offer{
+		Title:    "Nintendo 64",
+		Price:    250,
+		Link:     "https://example.com/offer",
+		Source:   "OLX",
+		Tags:     []string{"console", "retro"},
+		PostDate: time.Date(2025, time.January, 2, 3, 4, 0, 0, time.UTC),
+	}
+}
+
+func TestTelegramFormatOfferMessageDefaultTemplate(t *testing.T) {
+	adapter := NewTelegram("token", "chat")
+
+	msg, err := adapter.formatOfferMessage(testOffer(), "n64", true)
+	if err != nil {
+		t.Fatalf("formatOfferMessage returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Search: n64",
+		"NEW FIND ON OLX",
+		"Nintendo 64",
+		"R$ 250.00",
+		"console | retro",
+		"02/01/2025 at 03:04",
+		"https://example.com/offer",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestTelegramFormatOfferMessageCustomTemplate(t *testing.T) {
+	adapter := NewTelegram("token", "chat", domain.NotificationTemplates{
+		NewOffer: "{{.Title}}|{{.Price}}|{{.Link}}|{{.Date}}",
+	})
+
+	msg, err := adapter.formatOfferMessage(testOffer(), "", false)
+	if err != nil {
+		t.Fatalf("formatOfferMessage returned error: %v", err)
+	}
+
+	want := "Nintendo 64|R$ 250.00|https://example.com/offer|02/01/2025 at 03:04"
+	if msg != want {
+		t.Fatalf("message = %q, want %q", msg, want)
+	}
+}
+
+func TestGotifyFormatOfferMessageDefaultTemplate(t *testing.T) {
+	adapter := NewGotify("https://gotify.example", "token")
+
+	msg, err := adapter.formatOfferMessage(testOffer(), "n64", true)
+	if err != nil {
+		t.Fatalf("formatOfferMessage returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Search: n64",
+		"New find on OLX",
+		"Nintendo 64",
+		"R$ 250.00",
+		"02/01/2025 at 03:04",
+		"https://example.com/offer",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestGotifyFormatOfferMessageCustomTemplate(t *testing.T) {
+	adapter := NewGotify("https://gotify.example", "token", domain.NotificationTemplates{
+		NewOffer: "{{.Title}}: {{.Price}}",
+	})
+
+	msg, err := adapter.formatOfferMessage(testOffer(), "", false)
+	if err != nil {
+		t.Fatalf("formatOfferMessage returned error: %v", err)
+	}
+
+	if msg != "Nintendo 64: R$ 250.00" {
+		t.Fatalf("message = %q", msg)
+	}
+}

--- a/internal/core/domain/configs.go
+++ b/internal/core/domain/configs.go
@@ -1,8 +1,75 @@
 package domain
 
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
 type AppSettings struct {
 	DefaultNotifier string `yaml:"default_notifier"`
 	UseTopics       *bool  `yaml:"use_topics"`
+}
+
+const (
+	NotificationTemplateNewOffer       = "new_offer"
+	NotificationTemplateCircuitBreaker = "circuit_breaker"
+	NotificationTemplateError          = "error"
+)
+
+type NotifierSettings struct {
+	Templates NotificationTemplates `yaml:"templates"`
+}
+
+type NotificationTemplates struct {
+	NewOffer       string `yaml:"new_offer"`
+	CircuitBreaker string `yaml:"circuit_breaker"`
+	Error          string `yaml:"error"`
+}
+
+func (t NotificationTemplates) Template(name string) string {
+	switch name {
+	case NotificationTemplateNewOffer:
+		return t.NewOffer
+	case NotificationTemplateCircuitBreaker:
+		return t.CircuitBreaker
+	case NotificationTemplateError:
+		return t.Error
+	default:
+		return ""
+	}
+}
+
+type NotificationTemplateData struct {
+	Title      string
+	Price      string
+	Link       string
+	Date       string
+	Cooldown   string
+	Error      string
+	Source     string
+	SearchTerm string
+	Tags       string
+}
+
+func RenderNotificationTemplate(customTemplate, defaultTemplate string, data NotificationTemplateData) (string, error) {
+	templateText := defaultTemplate
+	if strings.TrimSpace(customTemplate) != "" {
+		templateText = customTemplate
+	}
+
+	tmpl, err := template.New("notification").Parse(templateText)
+	if err != nil {
+		return "", fmt.Errorf("parse notification template: %w", err)
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, data); err != nil {
+		return "", fmt.Errorf("execute notification template: %w", err)
+	}
+
+	return out.String(), nil
 }
 
 type Search struct {
@@ -41,9 +108,10 @@ type FixedProxy struct {
 }
 
 type Config struct {
-	App        AppSettings     `yaml:"app"`
-	Scraper    ScraperSettings `yaml:"scraper"`
-	Proxy      Proxy           `yaml:"proxy"`
-	Categories []string        `yaml:"categories"`
-	Searches   []Search        `yaml:"searches"`
+	App        AppSettings      `yaml:"app"`
+	Notifier   NotifierSettings `yaml:"notifier"`
+	Scraper    ScraperSettings  `yaml:"scraper"`
+	Proxy      Proxy            `yaml:"proxy"`
+	Categories []string         `yaml:"categories"`
+	Searches   []Search         `yaml:"searches"`
 }

--- a/internal/core/domain/configs_test.go
+++ b/internal/core/domain/configs_test.go
@@ -1,0 +1,63 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNotificationTemplatesTemplate(t *testing.T) {
+	templates := NotificationTemplates{
+		NewOffer:       "offer",
+		CircuitBreaker: "circuit",
+		Error:          "error",
+	}
+
+	tests := map[string]string{
+		NotificationTemplateNewOffer:       "offer",
+		NotificationTemplateCircuitBreaker: "circuit",
+		NotificationTemplateError:          "error",
+		"unknown":                          "",
+	}
+
+	for name, want := range tests {
+		if got := templates.Template(name); got != want {
+			t.Fatalf("Template(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestRenderNotificationTemplateUsesDefaultWhenCustomIsEmpty(t *testing.T) {
+	got, err := RenderNotificationTemplate("", "cooling down for {{.Cooldown}}", NotificationTemplateData{
+		Cooldown: "15m0s",
+	})
+	if err != nil {
+		t.Fatalf("RenderNotificationTemplate returned error: %v", err)
+	}
+
+	if got != "cooling down for 15m0s" {
+		t.Fatalf("rendered message = %q", got)
+	}
+}
+
+func TestRenderNotificationTemplateUsesCustomTemplate(t *testing.T) {
+	got, err := RenderNotificationTemplate("{{.Title}} costs {{.Price}} at {{.Link}}", "default", NotificationTemplateData{
+		Title: "Nintendo 64",
+		Price: "R$ 250.00",
+		Link:  "https://example.com/offer",
+	})
+	if err != nil {
+		t.Fatalf("RenderNotificationTemplate returned error: %v", err)
+	}
+
+	for _, want := range []string{"Nintendo 64", "R$ 250.00", "https://example.com/offer"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered message %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestRenderNotificationTemplateReturnsParseErrors(t *testing.T) {
+	if _, err := RenderNotificationTemplate("{{.Title", "default", NotificationTemplateData{}); err == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/internal/core/services/gorimpo.go
+++ b/internal/core/services/gorimpo.go
@@ -28,6 +28,11 @@ type GorimpoService struct {
 	circuitBreakerCounter int
 }
 
+const (
+	defaultCircuitBreakerTemplate = "🚧 <b>CIRCUIT BREAKER ACTIVATED!</b>\n3 consecutive failures. Entering cooldown of {{.Cooldown}}."
+	defaultErrorTemplate          = "📸 Error searching: {{.SearchTerm}}"
+)
+
 func NewGorimpoService(
 	s ports.Scraper,
 	or ports.OfferRepository,
@@ -122,7 +127,14 @@ func (g *GorimpoService) processSearch(search domain.Search) {
 
 		if visual, ok := g.scraper.(ports.VisualScraper); ok {
 			if img := visual.GetLastScreenshot(); img != nil {
-				g.notifier.SendPhoto(img, "📸 Error searching: "+search.Term, "system")
+				g.notifier.SendPhoto(img, g.renderNotificationTemplate(
+					domain.NotificationTemplateError,
+					defaultErrorTemplate,
+					domain.NotificationTemplateData{
+						SearchTerm: search.Term,
+						Error:      err.Error(),
+					},
+				), "system")
 			}
 		}
 
@@ -138,7 +150,11 @@ func (g *GorimpoService) processSearch(search domain.Search) {
 				"circuit_breaker_cooldown", cooldown,
 			)
 
-			msg := fmt.Sprintf("🚧 <b>CIRCUIT BREAKER ACTIVATED!</b>\n3 consecutive failures. Entering cooldown of %v.", cooldown)
+			msg := g.renderNotificationTemplate(
+				domain.NotificationTemplateCircuitBreaker,
+				defaultCircuitBreakerTemplate,
+				domain.NotificationTemplateData{Cooldown: cooldown.String()},
+			)
 			g.notifier.SendText(msg, "system")
 		}
 		return
@@ -231,6 +247,30 @@ func (g *GorimpoService) processSearch(search domain.Search) {
 		)
 		time.Sleep(time.Duration(sleep) * time.Second)
 	}
+}
+
+func (g *GorimpoService) renderNotificationTemplate(
+	name string,
+	defaultTemplate string,
+	data domain.NotificationTemplateData,
+) string {
+	msg, err := domain.RenderNotificationTemplate(
+		g.config.Get().Notifier.Templates.Template(name),
+		defaultTemplate,
+		data,
+	)
+	if err != nil {
+		slog.Error("Error rendering notification template", "template", name, "error", err)
+
+		fallback, fallbackErr := domain.RenderNotificationTemplate("", defaultTemplate, data)
+		if fallbackErr == nil {
+			return fallback
+		}
+
+		return defaultTemplate
+	}
+
+	return msg
 }
 
 func isExcluded(title string, excludes []string) bool {


### PR DESCRIPTION
## Summary
- add a notifier.templates config section for new_offer, circuit_breaker, and error messages
- render Go text/templates with fallback defaults for Telegram, Gotify, circuit-breaker, and scraper-error notifications
- document the YAML shape and cover template rendering with unit tests

Closes #12

## Verification
- gofmt
- go test ./...
- go build ./...