### PR TITLE
fix: parse OLX post dates in source timezone

### DIFF
--- a/internal/adapters/notifier/telegram.go
+++ b/internal/adapters/notifier/telegram.go
@@ -208,7 +208,7 @@ func formatTags(tags []string) string {
 }
 
 func formatDate(t time.Time) string {
-	now := time.Now()
+	now := time.Now().In(t.Location())
 	hour := t.Format("15:04")
 
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())

--- a/internal/adapters/scraper/olx/parser.go
+++ b/internal/adapters/scraper/olx/parser.go
@@ -1,6 +1,7 @@
 package olx
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,11 @@ type jsOffer struct {
 	PostDate   string   `json:"postDate"`
 }
 
+var (
+	olxPostTimeRE = regexp.MustCompile(`\b([01]?\d|2[0-3]):([0-5]\d)\b`)
+	olxLocation   = loadOLXLocation()
+)
+
 func parsePrice(p string) float64 {
 	p = strings.ReplaceAll(p, "R$", "")
 	p = strings.ReplaceAll(p, ".", "")
@@ -28,43 +34,99 @@ func parsePrice(p string) float64 {
 }
 
 func parseOLXDate(dateStr string) time.Time {
-	now := time.Now()
-	cleanStr := strings.ReplaceAll(strings.ToLower(dateStr), ",", "")
+	return parseOLXDateAt(dateStr, time.Now())
+}
 
-	parts := strings.Split(strings.ToLower(dateStr), ", ")
-	timePart := "00:00"
-	if len(parts) > 1 {
-		timePart = parts[1]
+func parseOLXDateAt(dateStr string, now time.Time) time.Time {
+	if strings.TrimSpace(dateStr) == "" {
+		return now.In(olxLocation)
 	}
 
-	t, _ := time.Parse("15:04", timePart)
+	now = now.In(olxLocation)
+	cleanStr := normalizeOLXDate(dateStr)
+	hour, minute := parseOLXTime(cleanStr)
 
-	if strings.Contains(dateStr, "hoje") {
-		return time.Date(now.Year(), now.Month(), now.Day(), t.Hour(), t.Minute(), 0, 0, now.Location())
+	if strings.Contains(cleanStr, "hoje") {
+		return time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, olxLocation)
 	}
 
-	if strings.Contains(dateStr, "ontem") {
+	if strings.Contains(cleanStr, "ontem") {
 		yesterday := now.AddDate(0, 0, -1)
-		return time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), t.Hour(), t.Minute(), 0, 0, now.Location())
+		return time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), hour, minute, 0, 0, olxLocation)
 	}
 
 	months := map[string]time.Month{
-		"jan": time.January, "fev": time.February, "mar": time.March,
-		"abr": time.April, "mai": time.May, "jun": time.June,
-		"jul": time.July, "ago": time.August, "set": time.September,
-		"out": time.October, "nov": time.November, "dez": time.December,
+		"jan": time.January, "janeiro": time.January,
+		"fev": time.February, "fevereiro": time.February,
+		"mar": time.March, "marco": time.March, "março": time.March,
+		"abr": time.April, "abril": time.April,
+		"mai": time.May, "maio": time.May,
+		"jun": time.June, "junho": time.June,
+		"jul": time.July, "julho": time.July,
+		"ago": time.August, "agosto": time.August,
+		"set": time.September, "setembro": time.September,
+		"out": time.October, "outubro": time.October,
+		"nov": time.November, "novembro": time.November,
+		"dez": time.December, "dezembro": time.December,
 	}
 
 	fields := strings.Fields(cleanStr)
-	if len(fields) >= 3 {
-		dia, _ := strconv.Atoi(fields[0])
-		mesStr := fields[2]
-		if mes, ok := months[mesStr]; ok {
-			return time.Date(now.Year(), mes, dia, t.Hour(), t.Minute(), 0, 0, now.Location())
+	for i, field := range fields {
+		day, err := strconv.Atoi(field)
+		if err != nil || day < 1 || day > 31 || i+1 >= len(fields) {
+			continue
 		}
+		month, ok := months[fields[i+1]]
+		if !ok {
+			continue
+		}
+		year := now.Year()
+		if i+2 < len(fields) {
+			if parsedYear, err := strconv.Atoi(fields[i+2]); err == nil && parsedYear >= 2000 {
+				year = parsedYear
+			}
+		}
+		parsed := time.Date(year, month, day, hour, minute, 0, 0, olxLocation)
+		if parsed.After(now.Add(24 * time.Hour)) {
+			parsed = parsed.AddDate(-1, 0, 0)
+		}
+		return parsed
 	}
 
 	return now
+}
+
+func normalizeOLXDate(dateStr string) string {
+	replacer := strings.NewReplacer(
+		",", " ",
+		".", " ",
+		"postado em", " ",
+		"publicado em", " ",
+		"às", " ",
+		" as ", " ",
+		" de ", " ",
+	)
+	clean := strings.ToLower(strings.TrimSpace(dateStr))
+	clean = replacer.Replace(clean)
+	return strings.Join(strings.Fields(clean), " ")
+}
+
+func parseOLXTime(cleanStr string) (int, int) {
+	match := olxPostTimeRE.FindStringSubmatch(cleanStr)
+	if len(match) != 3 {
+		return 0, 0
+	}
+	hour, _ := strconv.Atoi(match[1])
+	minute, _ := strconv.Atoi(match[2])
+	return hour, minute
+}
+
+func loadOLXLocation() *time.Location {
+	loc, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		return time.FixedZone("America/Sao_Paulo", -3*60*60)
+	}
+	return loc
 }
 
 func (o *Adapter) mapToDomain(items []jsOffer) []domain.Offer {

--- a/internal/adapters/scraper/olx/parser_test.go
+++ b/internal/adapters/scraper/olx/parser_test.go
@@ -1,0 +1,67 @@
+package olx
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseOLXDateUsesSaoPauloForRelativeDates(t *testing.T) {
+	now := time.Date(2026, time.May, 20, 2, 30, 0, 0, time.UTC)
+
+	got := parseOLXDateAt("Postado em Hoje, 00:12", now)
+	want := time.Date(2026, time.May, 19, 0, 12, 0, 0, olxLocation)
+	if !got.Equal(want) || got.Location() != olxLocation {
+		t.Fatalf("today date = %s (%s), want %s (%s)", got, got.Location(), want, want.Location())
+	}
+
+	got = parseOLXDateAt("Postado em Ontem, 23:58", now)
+	want = time.Date(2026, time.May, 18, 23, 58, 0, 0, olxLocation)
+	if !got.Equal(want) {
+		t.Fatalf("yesterday date = %s, want %s", got, want)
+	}
+}
+
+func TestParseOLXDateHandlesAbsoluteMetadata(t *testing.T) {
+	now := time.Date(2026, time.May, 20, 12, 0, 0, 0, olxLocation)
+
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "full month with connector",
+			input: "Postado em 18 de maio às 09:45",
+			want:  time.Date(2026, time.May, 18, 9, 45, 0, 0, olxLocation),
+		},
+		{
+			name:  "abbreviated month",
+			input: "18 mai, 09:45",
+			want:  time.Date(2026, time.May, 18, 9, 45, 0, 0, olxLocation),
+		},
+		{
+			name:  "explicit year",
+			input: "31 dez 2025, 21:10",
+			want:  time.Date(2025, time.December, 31, 21, 10, 0, 0, olxLocation),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseOLXDateAt(tt.input, now)
+			if !got.Equal(tt.want) {
+				t.Fatalf("date = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOLXDateRollsFutureMonthBackOneYear(t *testing.T) {
+	now := time.Date(2026, time.January, 2, 12, 0, 0, 0, olxLocation)
+
+	got := parseOLXDateAt("Postado em 31 dez, 22:00", now)
+	want := time.Date(2025, time.December, 31, 22, 0, 0, 0, olxLocation)
+	if !got.Equal(want) {
+		t.Fatalf("date = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
Closes #2.

## Summary
- parse OLX post metadata in the OLX source timezone (`America/Sao_Paulo`) instead of the scraper host timezone
- handle `Postado em` / `Publicado em`, `Hoje`, `Ontem`, abbreviated month, full month, and explicit-year metadata forms
- keep notification relative-date checks aligned with the offer timestamp timezone
- add deterministic parser regression tests for relative dates, absolute metadata, and year rollover

## Verification
- `git diff --check`
- `go test ./internal/adapters/scraper/olx ./internal/adapters/notifier`
- `go test ./...`